### PR TITLE
Bug fix - df, qf issue, remove the default value for df

### DIFF
--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -161,7 +161,6 @@ class SolrSearchBackend(BaseSearchBackend):
 
         kwargs = {
             'fl': '* score',
-            'df': index.document_field,
         }
 
         if fields:


### PR DESCRIPTION
As per solr docs the desired behaviour is:
 qf - Query Fields: specifies the fields in the index on which to perform the query. If absent, defaults to df.

But haystack is  putting a default value for df, sets it to field named 'text' and mixes both df, qf?!
https://github.com/django-haystack/django-haystack/blob/master/haystack/constants.py#L10
https://github.com/django-haystack/django-haystack/blob/master/haystack/backends/solr_backend.py#L208

# Hey, thanks for contributing to Haystack. Please review [the contributor guidelines](https://django-haystack.readthedocs.io/en/latest/contributing.html) and confirm that [the tests pass](https://django-haystack.readthedocs.io/en/latest/running_tests.html) with at least one search engine.

# Once your pull request has been submitted, the full test suite will be executed on https://travis-ci.org/django-haystack/django-haystack/pull_requests. Pull requests with passing tests are far more likely to be reviewed and merged.